### PR TITLE
Handle 'namespace' property for new Android Gradle plugin versions

### DIFF
--- a/android/.idea/gradle.xml
+++ b/android/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Handle 'namespace' property for new Android Gradle plugin versions
+    if (project.hasProperty("android") && project.android.hasProperty("namespace")) {
+        namespace = "tap.company.go_sell_sdk_flutter"
+    }
     compileSdkVersion 34
 
     defaultConfig {


### PR DESCRIPTION
This handle is required to use the library with the new Android Gradle versions.